### PR TITLE
Patch migrate to new filter names

### DIFF
--- a/src/engine/patch.cpp
+++ b/src/engine/patch.cpp
@@ -92,6 +92,45 @@ void Patch::additionalFromStateImpl(TiXmlElement *root, uint32_t version)
 
                 k->QueryIntAttribute("mt", &tmp);
                 nd.config.mt = (sst::filtersplusplus::FilterSubModel)tmp;
+
+                if (version == 2)
+                {
+                    // version 2 -> version 3 is a.liv's rename of cutofdf, res, and trip
+                    if (nd.model == sst::filtersplusplus::FilterModel::CutoffWarp ||
+                        nd.model == sst::filtersplusplus::FilterModel::ResonanceWarp)
+                    {
+                        // Move the slope which was 1-4 0x30-x033 to the submodel
+                        // which is 0x30 - 0x33
+                        auto sm = (uint32_t)nd.config.st;
+                        nd.config.st = sst::filtersplusplus::Slope::UNSUPPORTED;
+                        nd.config.mt = (sst::filtersplusplus::FilterSubModel)(sm + 0x30);
+                    }
+
+                    if (nd.model == sst::filtersplusplus::FilterModel::TriPole)
+                    {
+                        // basically just moved submodel to passband and slope to submodel
+                        auto omst = (uint32_t)nd.config.mt;
+                        auto ost = (uint32_t)nd.config.st;
+                        switch (omst)
+                        {
+                        case 0x32: // LHL
+                            nd.config.pt = sst::filtersplusplus::Passband::LowHighLow;
+                            break;
+                        case 0x35: // HLH
+                            nd.config.pt = sst::filtersplusplus::Passband::HighLowHigh;
+                            break;
+                        case 0x37: // HHH
+                            nd.config.pt = sst::filtersplusplus::Passband::HighHighHigh;
+                            break;
+                        default:
+                        case 0x30: // LLL
+                            nd.config.pt = sst::filtersplusplus::Passband::LowLowLow;
+                            break;
+                        }
+                        nd.config.st = sst::filtersplusplus::Slope::UNSUPPORTED;
+                        nd.config.mt = (sst::filtersplusplus::FilterSubModel)(ost + 1);
+                    }
+                }
             }
             k = k->NextSiblingElement("filter");
         }

--- a/src/engine/patch.h
+++ b/src/engine/patch.h
@@ -64,7 +64,7 @@ struct Param : pats::ParamBase, sst::cpputils::active_set_overlay<Param>::partic
 
 struct Patch : pats::PatchBase<Patch, Param>
 {
-    static constexpr uint32_t patchVersion{2};
+    static constexpr uint32_t patchVersion{3};
     static constexpr const char *id{"org.baconpaul.two-filters"};
 
     static constexpr uint32_t floatFlags{CLAP_PARAM_IS_AUTOMATABLE};


### PR DESCRIPTION
in sst-filters 1b9a6031 we finalized the enums for the filter models. This adapts to that change by upping patch version and writing a migrator in additionalFromStateImpl

Closes #26