### PR TITLE
Fix very-long lfo drift

### DIFF
--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -327,10 +327,15 @@ void Engine::processUIQueue(const clap_output_events_t *outq)
                 {
                     SQLOG("Non-begin/end bound param edit for '" << dest->meta.name << "'");
                 }
-                if (dest->meta.type == md_t::FLOAT)
+                if (dest->meta.type == md_t::FLOAT &&
+                    (dest->adhocFeatures & Param::AdHocFeatureValues::DONT_SMOOTH) == 0)
+                {
                     lagHandler.setNewDestination(&(dest->value), uiM->value);
+                }
                 else
+                {
                     dest->value = uiM->value;
+                }
 
                 clap_event_param_value_t p;
                 p.header.size = sizeof(clap_event_param_value_t);

--- a/src/engine/patch.h
+++ b/src/engine/patch.h
@@ -47,6 +47,7 @@ struct Param : pats::ParamBase, sst::cpputils::active_set_overlay<Param>::partic
     uint64_t adhocFeatures{0};
     enum AdHocFeatureValues : uint64_t
     {
+        DONT_SMOOTH = 1 << 0
     };
 
     bool isTemposynced() const
@@ -419,6 +420,7 @@ struct Patch : pats::PatchBase<Patch, Param>
                   })),
               MorphTargetMixin(gn(i), id(20, i))
         {
+            rate.adhocFeatures = Param::AdHocFeatureValues::DONT_SMOOTH;
         }
 
         std::string gn(int i) const { return "Step LFO " + std::to_string(i + 1); }


### PR DESCRIPTION
mostly by fixing the step sequencer but also avoid the smoothing of the stepped lfo rate

Closes #29 