### PR TITLE
Tweak the restart bar logic

### DIFF
--- a/src/clap/plugin-clap.cpp
+++ b/src/clap/plugin-clap.cpp
@@ -161,7 +161,6 @@ struct TwoFilters : public plugHelper_t, sst::clap_juce_shim::EditorProvider
         return CLAP_PROCESS_CONTINUE;
     }
 
-    int priorBarNumber{-1};
     template <Engine::RoutingModes routingMode, bool withFeedback, bool withNoise, bool withOS>
     clap_process_status processForRouting(const clap_process *process) noexcept
     {

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -144,8 +144,7 @@ void Engine::processControl(const clap_output_events_t *outq)
     {
         auto mMul = 1 << rtm;
         auto isCand = (int)transport.timeInBeats % ((int)(mMul * beatsPerMeasure));
-        if (transport.timeInBeats >= transport.lastBarStartInBeats + beatsPerMeasure &&
-            !didResetInLargerBlock)
+        if (transport.timeInBeats >= lastRestartBeat + beatsPerMeasure && !didResetInLargerBlock)
         {
             if (isCand == 0)
             {
@@ -552,6 +551,11 @@ void Engine::restartLfos()
     lfos[0].retrigger();
     lfos[1].retrigger();
     sendUpdateLfo();
+
+    // An assumption here that we are at a tempo where blockSize < 1 quarter note.
+    // Since blockSize == 8, thats basically capping us out at 6000bpm, which I think
+    // is fine :)
+    lastRestartBeat = (int64_t)std::floor(transport.timeInBeats);
 }
 
 void Engine::sendUpdateLfo()

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -84,6 +84,7 @@ struct Engine
     void updateLfoStorage();
     static void updateLfoStorageFromTo(const Patch &p, int node, stepLfo_t::Storage &to);
 
+    int64_t lastRestartBeat{-1};
     void restartLfos();
 
     bool audioRunning{true};


### PR DESCRIPTION
Rather than depending on transport.startOfBar use an internal last retriggered state to figure out when we cross, which I think will fix a problem of not retriggering when you exactly hit a bar start in transport, addressing #37