### PR TITLE
Fix a nyquist problem with cutoff

### DIFF
--- a/src/clap/plugin-clap.cpp
+++ b/src/clap/plugin-clap.cpp
@@ -61,7 +61,7 @@ struct TwoFilters : public plugHelper_t, sst::clap_juce_shim::EditorProvider
         clapJuceShim = std::make_unique<sst::clap_juce_shim::ClapJuceShim>(this);
         clapJuceShim->setResizable(true);
     }
-    virtual ~TwoFilters(){};
+    virtual ~TwoFilters() {}
 
     std::unique_ptr<Engine> engine;
     size_t blockPos{0};

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -51,6 +51,11 @@ void Engine::setSampleRate(double sr)
 
     audioToUi.push({AudioToUIMsg::SEND_SAMPLE_RATE, 0, (float)sampleRate});
 
+    auto nq = sampleRate * 0.495;
+    // so we are note from 69 which is 440
+    // freq = 440 2^(note/12)
+    // 12 log2(freq/440) = note
+    maxCutoff = 12.0 * log2(nq / 440.0);
     reassignLfos();
     sendUpdateLfo();
     for (int i = 0; i < numFilters; ++i)
@@ -170,7 +175,7 @@ void Engine::processControl(const clap_output_events_t *outq)
         auto &fn = patch.filterNodes[i];
         auto &sn = patch.stepLfoNodes[i];
 
-        float co = fn.cutoff;
+        float co = std::min((float)fn.cutoff, (float)(maxCutoff * (overSampling + 1)));
         float re = fn.resonance;
         float mo = fn.morph;
         for (int j = 0; j < numStepLFOs; ++j)

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -91,6 +91,7 @@ struct Engine
     int beginEndParamGestureCount{0};
 
     double sampleRate{1}, sampleRateInv{1};
+    double maxCutoff{0};
     void setSampleRate(double sampleRate);
 
     bool didResetInLargerBlock{false};

--- a/src/presets/preset-manager.cpp
+++ b/src/presets/preset-manager.cpp
@@ -58,8 +58,7 @@ PresetManager::PresetManager(const clap_host_t *ch) : clapHost(ch)
                     ents.push_back(p.filename());
                 }
 
-                std::sort(ents.begin(), ents.end(),
-                          [](const auto &a, const auto &b)
+                std::sort(ents.begin(), ents.end(), [](const auto &a, const auto &b)
                           { return strnatcasecmp(a.c_str(), b.c_str()) < 0; });
                 factoryPatchNames[d.filename()] = ents;
             }

--- a/src/ui/filter-panel.cpp
+++ b/src/ui/filter-panel.cpp
@@ -460,13 +460,11 @@ FilterPanel::FilterPanel(PluginEditor &ed, int ins)
 
     activeD = std::make_unique<PatchDiscrete>(editor, fn.active.meta.id);
     setToggleDataSource(activeD.get());
-    toggleButton->onBeginEdit = [this, &fn]() {
-        editor.mainToAudio.push({Engine::MainToAudioMsg::Action::BEGIN_EDIT, fn.active.meta.id});
-    };
+    toggleButton->onBeginEdit = [this, &fn]()
+    { editor.mainToAudio.push({Engine::MainToAudioMsg::Action::BEGIN_EDIT, fn.active.meta.id}); };
 
-    toggleButton->onEndEdit = [this, &fn]() {
-        editor.mainToAudio.push({Engine::MainToAudioMsg::Action::END_EDIT, fn.active.meta.id});
-    };
+    toggleButton->onEndEdit = [this, &fn]()
+    { editor.mainToAudio.push({Engine::MainToAudioMsg::Action::END_EDIT, fn.active.meta.id}); };
     editor.componentRefreshByID[fn.active.meta.id] = [this]() { onModelChanged(); };
 
     activeD->onGuiSetValue = [this]() { onModelChanged(); };

--- a/src/ui/plugin-editor.cpp
+++ b/src/ui/plugin-editor.cpp
@@ -112,9 +112,9 @@ PluginEditor::PluginEditor(Engine::audioToUIQueue_t &atou, Engine::mainToAudioQu
     sst::jucegui::component_adapters::setTraversalId(presetButton.get(), 174);
 
     // this needs a cleanup
-    defaultsProvider = std::make_unique<defaultsProvider_t>(
-        presetManager->userPath, "TwoFilters", defaultName,
-        [](auto e, auto b) { SQLOG("[ERROR]" << e << " " << b); });
+    defaultsProvider = std::make_unique<defaultsProvider_t>(presetManager->userPath, "TwoFilters",
+                                                            defaultName, [](auto e, auto b)
+                                                            { SQLOG("[ERROR]" << e << " " << b); });
     setSkinFromDefaults();
 
     lnf = std::make_unique<sst::jucegui::style::LookAndFeelManager>(this);
@@ -570,10 +570,9 @@ void PluginEditor::showPresetPopup()
             {
                 noExt = noExt.substr(0, ps);
             }
-            em.addItem(noExt,
-                       [cat = c, pat = e, this]() {
-                           this->presetManager->loadFactoryPreset(patchCopy, mainToAudio, cat, pat);
-                       });
+            em.addItem(
+                noExt, [cat = c, pat = e, this]()
+                { this->presetManager->loadFactoryPreset(patchCopy, mainToAudio, cat, pat); });
         }
         f.addSubMenu(c, em);
     }


### PR DESCRIPTION
Some filters are unstable above nyq (duh) but our control would let you slam them at 44.1 which made them blow up. So figure out a max functional cutoff and clamp there to avoid both user driven and modulation driven problems

Also I upgaded to format 21, so some noise from that